### PR TITLE
Добавил обработку ошибки при авторизации пользователя

### DIFF
--- a/Navigat1on/LogIn/LogInViewModel.swift
+++ b/Navigat1on/LogIn/LogInViewModel.swift
@@ -65,18 +65,13 @@ final class LogInViewModel {
             Checker.shared.check(logIn: log, pswrd: pswrd) { [weak self] result in
                 DispatchQueue.main.sync {
                     switch result {
-                    case .success(user: let user):
+                    case .success(let user):
                         self?.state = .loaded
                         (self?.coordinator as? LogInCoordinator)?.pushMainTabBarController(user: user)
-                    case .wrongLogIn:
+                        
+                    case .failure(let error):
                         self?.state = .loaded
-                        self?.state = .wrong(text: "Неправильный логин")
-                    case .wrongPswrd:
-                        self?.state = .loaded
-                        self?.state = .wrong(text: "Неправильный пароль")
-                    case .noLogInData:
-                        self?.state = .loaded
-                        self?.state = .wrong(text: "Введите логин")
+                        self?.state = .wrong(text: error.description)
                     }
                 }
             }
@@ -87,7 +82,6 @@ final class LogInViewModel {
         }
         
     }
-    
     
     func keyboardNotification(_ stateKeyboard: ServiseContentOfSet.StateK, _ notification: Notification) {
         let y = self.servise.ServiseContentOfSet(notification, stateK: stateKeyboard)

--- a/Navigat1on/LogIn/Model/TestUserServise.swift
+++ b/Navigat1on/LogIn/Model/TestUserServise.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class TestUserServise: UserServise {
     
-    private let user = User(login: "",
+    private let user = User(login: "q",
                     fullName: "TestLogin",
                     avatar: UIImage(systemName: "person.fill.questionmark"),
                     status: "TestStatus"


### PR DESCRIPTION
Я когда я делал изначально прочерку авторизации, я видел в примерах, что использовали result<..., Error >
Но я не знал реализации
Решил, что сначала реализую как то по своему, а потом нам объяснят, как правильно, там и переделаю
Собственно, время пришло))

Функционал был почти такой же, я просто подправил код
Вместо Enum Result 
с case и успех, и ошибки все
сделал отдельный Enum CheckerError
по фатку тот же мой старый enun, только без case .success

Так же внутреннюю функцию в Checker изменил в соответствии с задачей, (do { } catch { })