### PR TITLE
Закончил домашнюю работу

### DIFF
--- a/Navigat1on.xcodeproj/project.pbxproj
+++ b/Navigat1on.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		A48049032983DF54009FAA66 /* TabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48049022983DF54009FAA66 /* TabBarCoordinator.swift */; };
 		A4804907298403E6009FAA66 /* ServiseContentOfSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4804906298403E6009FAA66 /* ServiseContentOfSet.swift */; };
 		A480490C298A658D009FAA66 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A480490B298A658D009FAA66 /* ProfileView.swift */; };
+		A49AE016299CD24F000E14D3 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49AE015299CD24F000E14D3 /* NetworkService.swift */; };
 		A4E427D829818D9400A249F0 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E427D729818D9400A249F0 /* User.swift */; };
 		A4E427DA29818DD000A249F0 /* UserServiseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E427D929818DD000A249F0 /* UserServiseProtocol.swift */; };
 		A4E427DC29818DE300A249F0 /* CurrentUserServise.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E427DB29818DE300A249F0 /* CurrentUserServise.swift */; };
@@ -129,6 +130,7 @@
 		A48049022983DF54009FAA66 /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
 		A4804906298403E6009FAA66 /* ServiseContentOfSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiseContentOfSet.swift; sourceTree = "<group>"; };
 		A480490B298A658D009FAA66 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		A49AE015299CD24F000E14D3 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		A4E427D729818D9400A249F0 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		A4E427D929818DD000A249F0 /* UserServiseProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiseProtocol.swift; sourceTree = "<group>"; };
 		A4E427DB29818DE300A249F0 /* CurrentUserServise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserServise.swift; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 		A43698782979A89700395E32 /* Navigat1on */ = {
 			isa = PBXGroup;
 			children = (
+				A49AE012299CD206000E14D3 /* NetworkService */,
 				A4804912298EC0FB009FAA66 /* Archive */,
 				A436988E2979AA2000395E32 /* Application */,
 				A43698DF29800B5600395E32 /* CustomUI */,
@@ -378,6 +381,14 @@
 				A436989E2979AB6600395E32 /* TabBarController.swift */,
 			);
 			path = Archive;
+			sourceTree = "<group>";
+		};
+		A49AE012299CD206000E14D3 /* NetworkService */ = {
+			isa = PBXGroup;
+			children = (
+				A49AE015299CD24F000E14D3 /* NetworkService.swift */,
+			);
+			path = NetworkService;
 			sourceTree = "<group>";
 		};
 		A4E427E12982C14100A249F0 /* Protocol */ = {
@@ -529,6 +540,7 @@
 				A43698B12979AC9D00395E32 /* PhotosViewController.swift in Sources */,
 				A43698AB2979AC4900395E32 /* ProfileHeaderView.swift in Sources */,
 				A426E46D29817093001128BF /* LogInViewController.swift in Sources */,
+				A49AE016299CD24F000E14D3 /* NetworkService.swift in Sources */,
 				A436989B2979AADF00395E32 /* DataPosts.swift in Sources */,
 				A426E46B2981700A001128BF /* LogInViewModel.swift in Sources */,
 				A4E427DE29818DF100A249F0 /* TestUserServise.swift in Sources */,

--- a/Navigat1on/Application/SceneDelegate.swift
+++ b/Navigat1on/Application/SceneDelegate.swift
@@ -24,6 +24,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = mainCoordinator?.start()
         window.makeKeyAndVisible()
         self.window = window
+        
+        let appConfiguration = AppConfiguration.ferstUrl(string: "https://swapi.dev/api/people/8")
+        NetworkService.reguest(for: appConfiguration)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Navigat1on/NetworkService/NetworkService.swift
+++ b/Navigat1on/NetworkService/NetworkService.swift
@@ -1,0 +1,81 @@
+//
+//  NetworkService.swift
+//  Navigat1on
+//
+//  Created by Илья Сидорик on 15.02.2023.
+//
+
+import Foundation
+
+struct NetworkService {
+    static func reguest(for configurtion: AppConfiguration) {
+        guard let url = configurtion.url else {
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: url) { date, response, error in
+            guard let date = date,
+                  let response = response as? HTTPURLResponse
+            else {
+                guard let error = error else {
+                    return
+                }
+                print(error.localizedDescription)
+                return
+            }
+            
+            do {
+                guard let dateDictionari = try JSONSerialization.jsonObject(with: date) as? [String : Any] else {
+                    print("Не удалось скастить данные из date до [String : Any]")
+                    return
+                }
+                dateDictionari.forEach( {print("\nKey: \($0) \nValue: \($1)")} )
+            }
+            catch {
+                print(error)
+            }
+            
+            print("\nAll header fields")
+            response.allHeaderFields.forEach({ print("\n\($0) \n\($1)") })
+            
+            print("\nStatus code: \(response.statusCode)")
+        }
+        task.resume()
+    }
+   
+}
+
+
+enum AppConfiguration {
+    case ferstUrl(string: String)
+    case secondUrl(string: String)
+    case thirdUrl(string: String)
+    
+    var url: URL? {
+        switch self {
+        case .ferstUrl(string: let string):
+            guard let url = URL(string: string) else {
+                return nil
+            }
+            return url
+            
+        case .secondUrl(string: let string):
+            guard let url = URL(string: string) else {
+                return nil
+            }
+            return url
+            
+        case .thirdUrl(string: let string):
+            guard let url = URL(string: string) else {
+                return nil
+            }
+            return url
+        }
+    }
+    
+//    init(ferstUrl: String, secondUrl: String, thirdUrl: String) {
+//        self = .ferstUrl(string: ferstUrl)
+//        self = .secondUrl(string: secondUrl)
+//        self = .thirdUrl(string: thirdUrl)
+//    }
+}


### PR DESCRIPTION
Добавил NetworkService
вызвал метод в SceneDelegate

У меня в любом раскладе в логах появляется этот код:
2023-02-16 16:45:37.013371+0700 Navigat1on[29338:1168608] [boringssl] boringssl_metrics_log_metric_block_invoke(153) Failed to log metrics

Подскажите, пожалуйста, что это)

По заданию комментарии, как указанно в дз.

Код у error.localizedDescription следующий:
The Internet connection appears to be offline.

По мимо этого, у логах  выходит следующий код:
2023-02-16 16:51:24.756182+0700 Navigat1on[29517:1173855] Connection 1: received failure notification
2023-02-16 16:51:24.756381+0700 Navigat1on[29517:1173855] Connection 1: failed to connect 1:50, reason -1
2023-02-16 16:51:24.756727+0700 Navigat1on[29517:1173855] Connection 1: encountered error(1:50)
2023-02-16 16:51:24.758914+0700 Navigat1on[29517:1173855] Task <522B2595-D49D-49B6-951C-E41731369D8B>.<1> HTTP load failed, 0/0 bytes (error code: -1009 [1:50])
2023-02-16 16:51:24.780116+0700 Navigat1on[29517:1173855] Task <522B2595-D49D-49B6-951C-E41731369D8B>.<1> finished with error [-1009] Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline." UserInfo={_kCFStreamErrorCodeKey=50, NSUnderlyingError=0x60000249cff0 {Error Domain=kCFErrorDomainCFNetwork Code=-1009 "(null)" UserInfo={_NSURLErrorNWPathKey=unsatisfied (No network route), _kCFStreamErrorCodeKey=50, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <522B2595-D49D-49B6-951C-E41731369D8B>.<1>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <522B2595-D49D-49B6-951C-E41731369D8B>.<1>"
), NSLocalizedDescription=The Internet connection appears to be offline., NSErrorFailingURLStringKey=https://swapi.dev/api/people/8, NSErrorFailingURLKey=https://swapi.dev/api/people/8, _kCFStreamErrorDomainKey=1}
